### PR TITLE
Fix typo "outputFilename" configuration setting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The reporter will generate a `test-report.xml` file in the project root. If you 
 ```json
 "jestNunitReporter": {
   "outputPath": "reports/",
-  "outputFileName": "custom-report.xml",
+  "outputFilename": "custom-report.xml",
 }
 ```
 


### PR DESCRIPTION
This cost me half an hour of debugging or so until I found out why it didn't work... ;)
